### PR TITLE
Update TerminalNotifier.py

### DIFF
--- a/pync/TerminalNotifier.py
+++ b/pync/TerminalNotifier.py
@@ -57,6 +57,8 @@ class TerminalNotifier(object):
 
     def execute(self, args):
         output = subprocess.Popen([self.bin_path, ] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        output.wait()
+        
         if output.returncode:
             raise Exception("Some error during subprocess call.")
         return output


### PR DESCRIPTION
when using in a script loaded by launchd then we need to .wait() - otherwise the process gets killed before it's actually called
