### PR TITLE
Ensure all subprocess.Popen args are strings and fix small typo

### DIFF
--- a/pync/TerminalNotifier.py
+++ b/pync/TerminalNotifier.py
@@ -6,7 +6,7 @@ import platform
 import subprocess
 from dateutil.parser import parse
 
-LIST_FIELDS = ["group", "title", "sublitle", "message", "delivered_at"]
+LIST_FIELDS = ["group", "title", "subtitle", "message", "delivered_at"]
 
 
 class TerminalNotifier(object):
@@ -64,6 +64,7 @@ class TerminalNotifier(object):
         return self.execute(args)
 
     def execute(self, args):
+        args = [str(arg) for arg in args]
         output = subprocess.Popen([self.bin_path, ] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         if self.wait:


### PR DESCRIPTION
When running `Notifier.list(os.getpid())` (as per the documentation example), I get the following error:

```
File "/System/Library/Frameworks/Python.framework/Version/2.7/lib/python2.7/subprocess.py", line 1228, in _execute_child
raise child_exception
TypeError: execv() arg 2 must contain only strings
```

Apparently `subprocess.Popen()` takes only string arguments. Line 67 ensures this. Also fixed a small typo "sublitle" -> "subtitle".
