### PR TITLE
Fix inclusion of vendor directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.md LICENSE
 global-exclude .DS_Store
+recursive-include pync/vendor *

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,6 @@ for root, dirs, files in os.walk('pync/vendor/'):
     for f in files:
         terminal_notifier_files.append(os.path.join(root, f))
 
-package_data = {
-    '': ['LICENSE', 'README.md'] + terminal_notifier_files,
-}
-
 setup(name = 'pync',
     version = "1.4",
     description = 'Python Wrapper for Mac OS 10.8 Notification Center',
@@ -36,7 +32,6 @@ setup(name = 'pync',
     install_requires = [
         'python-dateutil>=2.0'
     ],
-    package_data = package_data,
     packages = find_packages(),
     classifiers = [
         'Topic :: Utilities',


### PR DESCRIPTION
Also removed README.md and LICENSE from MANIFEST.in and package_data
from setup.py.

There was no reason for the readme and license to be in the manifest
template since setuptools by design doesn't extract non-package files.
(This could be circumvented by placing a duplicate file in the pync
package subdirectory)

The package_data option isn't needed so removed it.

fixes SeTeM/pync#15
