### PR TITLE
Fix importing 'notify'

### DIFF
--- a/pync/__init__.py
+++ b/pync/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "1.6.1"
 
-from .TerminalNotifier import Notifier
+from .TerminalNotifier import Notifier, notify


### PR DESCRIPTION
Readme says that `import pync` is enough to use `pync.notify(...)`. This is not valid without this little patch.