### PR TITLE
Fix module installation from PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 global-exclude .DS_Store
 recursive-include pync/vendor *
+include README.md

--- a/README.md
+++ b/README.md
@@ -1,37 +1,30 @@
-## ⚠️ Disclaimer
-I haven't been supporting the library for a long time, and if someone wants to take responsibility over it, contact me, please.
-
-
-pync
-====
+# pync
 
 A simple Python wrapper around the [`terminal-notifier`][HOMEPAGE] command-line tool (version 2.0.0), which allows you to send User Notifications to the Notification Center on Mac OS X 10.10, or higher.
 
 ![Screenshot](http://f.cl.ly/items/1k051n3k0u0i101m1i0U/Screen%20Shot%202012-08-24%20at%2012.20.40%20PM.png)
 
-Installation
-------------
+### Installation
 
-```
+```bash
 pip install pync
 ```
 or
-```
+```bash
 pip install git+https://github.com/SeTeM/pync.git
 ```
 or
-```
+```bash
 git clone git://github.com/SeTeM/pync.git
 cd pync
 python setup.py install
 ```
 
-Usage
------
+### Usage
 
 For full information on all the options, see the tool’s [README][README].
 
-### Examples:
+#### Examples:
 
 Using the notify function
 ```python
@@ -66,8 +59,7 @@ Notifier.list(os.getpid())
 ```
 
 
-License
--------
+### License
 
 All the works are available under the MIT license. **Except** for ‘Terminal.icns’, which is a copy of Apple’s Terminal.app icon and as such is copyright of Apple.
 

--- a/pync/__init__.py
+++ b/pync/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 from .TerminalNotifier import Notifier, notify

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,19 @@
 # -*- coding: utf-8 -*-
 
 import os
+import codecs
 from setuptools import setup, find_packages
 
-file_contents = []
-for file_name in ('README.md',):
-    path = os.path.join(os.path.dirname(__file__), file_name)
-    file_contents.append(open(path).read())
-long_description = '\n\n'.join(file_contents)
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+readme_file = os.path.join(here, 'README.md')
+try:
+    from m2r import parse_from_file
+    long_description = parse_from_file(readme_file)
+except ImportError:
+    with codecs.open(readme_file, encoding='utf-8') as f:
+        long_description = f.read()
 
 terminal_notifier_files = []
 for root, dirs, files in os.walk('pync/vendor/'):

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,13 @@ for root, dirs, files in os.walk('pync/vendor/'):
         terminal_notifier_files.append(os.path.join(root, f))
 
 setup(name = 'pync',
-    version = "2.0.0",
+    version = "2.0.1",
     description = 'Python Wrapper for Mac OS 10.10 Notification Center',
     long_description = long_description,
     author = 'Vladislav Syabruk',
     author_email = 'sjabrik@gmail.com',
     url = 'https://github.com/setem/pync',
-    download_url = 'https://github.com/SeTeM/pync/archive/v2.0.0.zip',
+    download_url = 'https://github.com/SeTeM/pync/archive/v2.0.1.zip',
     license = "MIT",
     platforms = "MacOS X",
     keywords = "mac notification center wrapper",


### PR DESCRIPTION
When pip installing module from PyPI firstly download dist files after that extract and execute `setup.py`, but in progress, it fails with this error:

```bash
Traceback (most recent call last):
        File "<string>", line 1, in <module>
	File "/private/tmp/pip-install-_d6vixsj/pync/setup.py", line 10, in <module>
    	     file_contents.append(open(path).read())
 FileNotFoundError: [Errno 2] No such file or directory:'/private/tmp/pip-install-....
----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-install-...
```
The reason why that happens is very simple in `MANIFEST.in` we should add the new instruction for including a `README.md` to distro packets
My changes fix that problem and also should fix troubles with formatting on pypi.org