### PR TITLE
New pync 2.0.3

### DIFF
--- a/pync/TerminalNotifier.py
+++ b/pync/TerminalNotifier.py
@@ -14,11 +14,12 @@ LIST_FIELDS = ["group", "title", "subtitle", "message", "delivered_at"]
 class TerminalNotifier(object):
     TERMINAL_NOTIFIER_VERSION = "2.0.0"
 
-    def __init__(self):
+    def __init__(self, wait=False):
         """
         Raises an exception if not supported on the current platform or
         if terminal-notifier was not found.
         """
+        self._wait = wait
         proc = subprocess.Popen(["which", "terminal-notifier"], stdout=subprocess.PIPE)
         env_bin_path = proc.communicate()[0].strip()
         if env_bin_path and os.path.exists(env_bin_path):
@@ -71,7 +72,7 @@ class TerminalNotifier(object):
         if sys.version_info < (3,):
             message = message.encode('utf-8')
 
-        self.wait = kwargs.pop('wait', False)
+        self._wait = kwargs.pop('wait', False)
 
         args = ['-message', message]
         args += [a for b in [("-%s" % arg, str(key)) for arg, key in kwargs.items()] for a in b]  # flatten list
@@ -82,7 +83,7 @@ class TerminalNotifier(object):
         args = [str(arg) for arg in args]
         output = subprocess.Popen([self.bin_path, ] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-        if self.wait:
+        if self._wait:
             output.wait()
 
         if output.returncode:
@@ -114,7 +115,7 @@ class TerminalNotifier(object):
         res = list()
 
         for line in output.splitlines()[1:]:
-            res.append(dict(zip(LIST_FIELDS, line.split("\t"))))
+            res.append(dict(zip(LIST_FIELDS, line.decode().split("\t"))))
             try:
                 res[-1]["delivered_at"] = parse(res[-1]["delivered_at"])
             except ValueError:

--- a/pync/__init__.py
+++ b/pync/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 from .TerminalNotifier import Notifier, notify

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,12 @@ for root, dirs, files in os.walk('pync/vendor/'):
         terminal_notifier_files.append(os.path.join(root, f))
 
 setup(name = 'pync',
-    version = "2.0.2",
+    version = "2.0.3",
     description = 'Python Wrapper for Mac OS 10.10 Notification Center',
     long_description = long_description,
     author = 'Vladislav Syabruk',
     author_email = 'sjabrik@gmail.com',
     url = 'https://github.com/setem/pync',
-    download_url = 'https://github.com/SeTeM/pync/archive/v2.0.1.zip',
     license = "MIT",
     platforms = "MacOS X",
     keywords = "mac notification center wrapper",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,15 @@ setup(name = 'pync',
     ],
     packages = find_packages(),
     classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Environment :: MacOS X',
+        'Topic :: Terminals',
         'Topic :: Utilities',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
First bug #35 
When call list() method on TerminalNotifier it fals with this error
```bash
>>> from pync import Notifier
>>> Notifier.list()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site packages/pync/TerminalNotifier.py", line 107, in list
    output = self.execute(["-list", group]).communicate()[0]
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site packages/pync/TerminalNotifier.py", line 79, in execute
    if self.wait:
AttributeError: 'TerminalNotifier' object has no attribute 'wait'
```

The reason of this behabior is simple. Notifier object was created without `wait`
 property and not inited in `notify` method.

ChangeID: https://github.com/SeTeM/pync/issues/35
# 