### PR TITLE
Removing the encoding seems to have resolved issues on py 2.7

### DIFF
--- a/pync/TerminalNotifier.py
+++ b/pync/TerminalNotifier.py
@@ -69,9 +69,6 @@ class TerminalNotifier(object):
           The options `wait` is a boolean for whether or not we need to wait (block) for the background process to finish
         """
 
-        if sys.version_info < (3,):
-            message = message.encode('utf-8', 'replace')
-
         self._wait = kwargs.pop('wait', False)
 
         args = ['-message', message]


### PR DESCRIPTION
I was wrong with my last one, it doesn't seem to need any encoding, this is on python 2.7. I'm not sure if my situation is different from the "norm", but for me, removing the re-assignment of `message` to encode it does in fact completely fix the issues I was having. My last fix I was still getting intermittent failures.

Sorry about that.